### PR TITLE
Add trampos title and fix required_skills regex

### DIFF
--- a/lib/jobbie/app.rb
+++ b/lib/jobbie/app.rb
@@ -12,12 +12,16 @@ module Jobbie
       @company = company
     end
 
+    def title
+      @title ||= title_text
+    end
+
     def seniority
       scan(%w(Junior Júnior Senior Sênior Pleno)).first
     end
 
     def required_skills
-      (@title || title_text).scan(regexp(@dictionary[:skills])).flatten
+      title.scan(regexp(@dictionary[:skills])).flatten
     end
 
     %w(focuses skills).each do |collection|
@@ -73,7 +77,7 @@ module Jobbie
     end
 
     def regexp(values)
-      /(?:\s(?:|\W)|^)(#{values.map { |value| Regexp.escape(value).gsub("\\ ", "[\\ \\-]") }.join("|")})(?:\s|\W\s)/i
+      /(?:\s(?:|\W)|^)(#{values.map { |value| Regexp.escape(value).gsub("\\ ", "[\\ \\-]") }.join("|")})(?:\s|\W\s|$)/i
     end
 
     def title_selector

--- a/lib/jobbie/trampos.rb
+++ b/lib/jobbie/trampos.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Jobbie
   class Trampos < App
     def location

--- a/lib/jobbie/trampos.rb
+++ b/lib/jobbie/trampos.rb
@@ -25,8 +25,12 @@ module Jobbie
       opportunities
     end
 
+    def title_selector
+      'h2'
+    end
+
     def title_text
-      doc.css("meta[name='title']").first.attr 'content'
+      super.gsub(/\#\w{2} /, '')
     end
 
     def document_text

--- a/spec/trampos_spec.rb
+++ b/spec/trampos_spec.rb
@@ -75,4 +75,12 @@ describe Jobbie::Trampos do
       end
     end
   end
+
+  describe '#title' do
+    it 'returns the title' do
+      VCR.use_cassette 'trampos-123892' do
+        expect(described_class.new(url: 'http://trampos.co/oportunidades/123892?tr=ruby').title).to eql 'Desenvolvedor(a) Back-end Pleno'
+      end
+    end
+  end
 end


### PR DESCRIPTION
- [x] Feature: add Trampos job title
- [x] Fix: now required_skills accepts skill words in the last text